### PR TITLE
format with DataAPI supported format for dates

### DIFF
--- a/sqlalchemy_aurora_data_api/__init__.py
+++ b/sqlalchemy_aurora_data_api/__init__.py
@@ -75,16 +75,30 @@ class _ADA_DATE(_ADA_DATETIME_MIXIN, DATE):
     py_type = datetime.date
     sa_type = sqltypes.Date
 
+    def bind_processor(self, dialect):
+        def process(value):
+            return value.strftime("%Y-%m-%d") if isinstance(value, self.py_type) else value
+        return process
+
 
 class _ADA_TIME(_ADA_DATETIME_MIXIN, TIME):
     py_type = datetime.time
     sa_type = sqltypes.Time
+
+    def bind_processor(self, dialect):
+        def process(value):
+            return value.strftime("%H:%M:%S") if isinstance(value, self.py_type) else value
+        return process
 
 
 class _ADA_TIMESTAMP(_ADA_DATETIME_MIXIN, TIMESTAMP):
     py_type = datetime.datetime
     sa_type = sqltypes.DateTime
 
+    def bind_processor(self, dialect):
+        def process(value):
+            return value.strftime("%Y-%m-%d %H:%M:%S") if isinstance(value, self.py_type) else value
+        return process
 
 class _ADA_ARRAY(ARRAY):
     def bind_processor(self, dialect):


### PR DESCRIPTION
I encountered a bug on the usage of TIMESTAMP columns on Aurora MySQL with the Data API, which couldn't insert/update date values as they were iso-formatted.

The Data API does not accept iso-formatted dates, they must follow a given format at https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html#data-api.calling.

This PR implements this change ensuring datetime objects get converted to the right format.