### PR TITLE
Tell SQLAlchemy: mysql supports native decimal (fixes #25)

### DIFF
--- a/sqlalchemy_aurora_data_api/__init__.py
+++ b/sqlalchemy_aurora_data_api/__init__.py
@@ -101,6 +101,7 @@ class AuroraMySQLDataAPIDialect(MySQLDialect):
     # See https://docs.sqlalchemy.org/en/13/core/internals.html#sqlalchemy.engine.interfaces.Dialect
     driver = "aurora_data_api"
     default_schema_name = None
+    supports_native_decimal = True
     colspecs = util.update_copy(MySQLDialect.colspecs, {
         sqltypes.Date: _ADA_DATE,
         sqltypes.Time: _ADA_TIME,


### PR DESCRIPTION
This change avoids an SQLAlchemy warning:

> SAWarning: Dialect mysql+aurora_data_api does not support Decimal objects natively, …