### PR TITLE
Set supports_sane_multi_rowcount = False on AuroraPostgresDataAPIDialect

### DIFF
--- a/sqlalchemy_aurora_data_api/__init__.py
+++ b/sqlalchemy_aurora_data_api/__init__.py
@@ -133,6 +133,7 @@ class AuroraPostgresDataAPIDialect(PGDialect):
         sqltypes.Enum: _ADA_ENUM,
         ARRAY: _ADA_ARRAY
     })
+    supports_sane_multi_rowcount = False
 
     @classmethod
     def dbapi(cls):


### PR DESCRIPTION
We were seeing this error from sqlalchemy:
```
            if check_rowcount:
                if rows != len(records):
>                   raise orm_exc.StaleDataError(
                        "UPDATE statement on table '%s' expected to "
                        "update %d row(s); %d were matched."
                        % (table.description, len(records), rows)
                    )
E                   sqlalchemy.orm.exc.StaleDataError: UPDATE statement on table 'test' expected to update 2 row(s); -1 were matched.

/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/persistence.py:1025: StaleDataError
```

sqlalchemy checks rowcount on executemany calls, but it's not provided by aurora-data-api for these cases, so the calls fail.
