### PR TITLE
Support for fractional seconds when binding time and datetime data types

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -140,6 +140,14 @@ class User(Base):
 
 
 class TestAuroraDataAPI(unittest.TestCase):
+    dialect = "postgresql+auroradataapi://"
+
+    @classmethod
+    def setUpClass(cls):
+        register_dialects()
+        cls.db_name = os.environ.get("AURORA_DB_NAME", __name__)
+        cls.engine = create_engine(cls.dialect + ':@/' + cls.db_name)
+
     @classmethod
     def tearDownClass(cls):
         pass
@@ -174,7 +182,7 @@ class TestAuroraDataAPIPostgresDialect(TestAuroraDataAPI):
         blob = b"0123456789ABCDEF" * 1024
         friends = ["Scarlett O'Hara", 'Ada "Hacker" Lovelace']
         Base.metadata.create_all(self.engine)
-        added = datetime.datetime.now()
+        added = datetime.datetime.now().replace(microsecond=123456)
         ed_user = User(name='ed', fullname='Ed Jones', nickname='edsnickname', doc=doc, doc2=doc, uuid=str(uuid),
                        flag=True, birthday=datetime.datetime.fromtimestamp(0), added=added, floated=1.2, nybbled=blob,
                        friends=friends, num_friends=500, num_laptops=9000, first_date=added, note='note',
@@ -195,7 +203,7 @@ class TestAuroraDataAPIPostgresDialect(TestAuroraDataAPI):
         self.assertEqual(u.flag, True)
         self.assertEqual(u.nonesuch, None)
         self.assertEqual(u.birthday, datetime.date.fromtimestamp(0))
-        self.assertEqual(u.added, added.replace(microsecond=0))
+        self.assertEqual(u.added, added.replace(microsecond=123000))
         self.assertEqual(u.floated, 1.2)
         self.assertEqual(u.nybbled, blob)
         self.assertEqual(u.friends, friends)
@@ -256,7 +264,7 @@ class TestAuroraDataAPIMySQLDialect(TestAuroraDataAPI):
         self.assertEqual(u.nickname, "edsnickname")
         self.assertEqual(u.birthday, birthday)
         self.assertEqual(u.eats_breakfast_at, eats_breakfast_at.replace(microsecond=0))
-        self.assertEqual(u.married_at, married_at.replace(microsecond=0))
+        self.assertEqual(u.married_at, married_at.replace(microsecond=200000))
 
 
 if __name__ == "__main__":

--- a/test/test.py
+++ b/test/test.py
@@ -140,14 +140,6 @@ class User(Base):
 
 
 class TestAuroraDataAPI(unittest.TestCase):
-    dialect = "postgresql+auroradataapi://"
-
-    @classmethod
-    def setUpClass(cls):
-        register_dialects()
-        cls.db_name = os.environ.get("AURORA_DB_NAME", __name__)
-        cls.engine = create_engine(cls.dialect + ':@/' + cls.db_name)
-
     @classmethod
     def tearDownClass(cls):
         pass

--- a/test/test.py
+++ b/test/test.py
@@ -256,7 +256,7 @@ class TestAuroraDataAPIMySQLDialect(TestAuroraDataAPI):
         self.assertEqual(u.nickname, "edsnickname")
         self.assertEqual(u.birthday, birthday)
         self.assertEqual(u.eats_breakfast_at, eats_breakfast_at.replace(microsecond=0))
-        self.assertEqual(u.married_at, married_at.replace(microsecond=200000))
+        self.assertEqual(u.married_at, married_at.replace(microsecond=0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the process of using this library internally, we've discovered that currently time and datetime values are formatted in a fashion that truncates sub-second precision prior to being sent to the data api. This PR adds a fractional second component to the values sent formatted in the fashion the data API expects (see https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html#data-api.calling for reference). Unfortunately as per the docs we cannot simply use the output of the `%f` directive, nor is it possible to directly use the output of `isoformat(timespec='milliseconds')`. I've tested this both in our  internal usage as well as by updating and running the tests in this package.